### PR TITLE
Correct the spelling of CocoaPods in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,10 +15,10 @@ Main Features
 * ... and many more handy features that RestKit offers
 
 
-Cocoapods
+CocoaPods
 ------------------------------
 
-You can install StorageRoomKit through Cocoapods:
+You can install StorageRoomKit through CocoaPods:
 
 `pod search 'StorageRoomKit'`
 
@@ -160,7 +160,7 @@ Contributions
 
 Thanks a lot to all contributors.
 
-- @andreacremaschi: Cocoapods support
+- @andreacremaschi: CocoaPods support
 
 License
 ------------------------------


### PR DESCRIPTION
This pull requests corrects the spelling of **CocoaPods** 🤓
https://github.com/CocoaPods/shared_resources/tree/master/media

<blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">One day I’ll make a bot that looks through the READMEs of all Pods, looks to see if it uses “Cocoapods” and PRs “CocoaPods” :D</p>&mdash; Ørta (@orta) <a href="https://twitter.com/orta/status/697374357975388160">February 10, 2016</a></blockquote>

<script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>


Created with [`cocoapods-readme`](https://github.com/dkhamsing/cocoapods-readme).  
